### PR TITLE
Update dependencies to fix possible security issue

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,15 +1,15 @@
 [[source]]
-url = "https://pypi.org/simple"
+url = 'https://pypi.org/simple'
 verify_ssl = true
-name = "pypi"
+name = 'pypi'
 
 [packages]
-requests = "*"
-robotframework-requests = "*"
-robotframework = "*"
-robotframework-websocketclient = "*"
+requests = '>2.20.0'
+robotframework-requests = '*'
+robotframework = '*'
+robotframework-websocketclient = '*'
 
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = '3.6'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a17f0755a18ca8fc38d33003af503246c9c0316c86b04536a9e24dd0252f2960"
+            "sha256": "3ecb4ed11888c43dda05735d40d0033584c20f0ae6d1044a94d26c33c6e7394c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.10.15"
         },
         "chardet": {
             "hashes": [
@@ -39,11 +39,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
-                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
             "index": "pypi",
-            "version": "==2.19.1"
+            "version": "==2.20.1"
         },
         "robotframework": {
             "hashes": [
@@ -54,10 +54,10 @@
         },
         "robotframework-requests": {
             "hashes": [
-                "sha256:bae166fcbb3b4227e52cec7f1edfd5ec696f25e26c393bcc0daa2d0dc313e3af"
+                "sha256:1c253b8061c8a91251abf3ebadc33152b8621671621405dd343efd17bdc9e620"
             ],
             "index": "pypi",
-            "version": "==0.4.7"
+            "version": "==0.5.0"
         },
         "robotframework-websocketclient": {
             "hashes": [
@@ -76,17 +76,18 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.23"
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version < '4'",
+            "version": "==1.24.1"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:18f1170e6a1b5463986739d9fd45c4308b0d025c1b2f9b88788d8f69e8a5eb4a",
-                "sha256:db70953ae4a064698b27ae56dcad84d0ee68b7b43cb40940f537738f38f510c1"
+                "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786",
+                "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849"
             ],
-            "version": "==0.48.0"
+            "version": "==0.54.0"
         }
     },
     "develop": {}


### PR DESCRIPTION
Closes #8 

There was a vulnerability in the `requests` package version < 2.20.0, this PR updates all dependencies to their latest version.