### PR TITLE
Fix failing tests after API update

### DIFF
--- a/tests/01__admin/01__admin_session_tests.robot
+++ b/tests/01__admin/01__admin_session_tests.robot
@@ -79,44 +79,43 @@ Request to reset password successfully with correct credentials
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${ADMIN_EMAIL}    redirect_url=${RESET_PASSWORD_URL}
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response
     Assert Response Success    ${resp}
+
+Request to reset password succeed with empty response if an invalid email is provided but no email sent
+    # Build payload
+    ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
+    &{override}    Create Dictionary    email=invalid@email.com    redirect_url=${RESET_PASSWORD_URL}
+    ${data}    Update Json    ${data}    &{override}
+    &{headers}    Build Admin Request Header
+    # Perform request
+    ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
+    # Assert response
+    Assert Response Success    ${resp}
+    Should Be Empty    ${resp.json()['data']}
 
 Request to reset password fails if required parameters are not provided
     # Build payload
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${None}    redirect_url=${RESET_PASSWORD_URL}
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response
     Assert Response Failure    ${resp}
-    Should be Equal    ${resp.json()['data']['code']}    client:invalid_parameter
-    Should be Equal    ${resp.json()['data']['description']}    Invalid parameter provided.
-
-Request to reset password fails if an invalid email is provided
-    # Build payload
-    ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
-    &{override}    Create Dictionary    email=invalid@email.com    redirect_url=${RESET_PASSWORD_URL}
-    ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
-    # Perform request
-    ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
-    # Assert response
-    Assert Response Failure    ${resp}
-    Should Be Equal    ${resp.json()['data']['code']}    user:email_not_found
-    Should Be Equal    ${resp.json()['data']['description']}    There is no user corresponding to the provided email.
+    Should Be Equal    ${resp.json()['data']['code']}    client:invalid_parameter
+    Should Be Equal    ${resp.json()['data']['description']}    `email` and `redirect_url` are required
 
 Request to reset password fails if an invalid redirect URL is provided
     # Build payload
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${ADMIN_EMAIL}    redirect_url=http://invalid.com
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response

--- a/tests/01__admin/resources/transaction_request/create_transaction_request_all_params.json
+++ b/tests/01__admin/resources/transaction_request/create_transaction_request_all_params.json
@@ -10,7 +10,7 @@
   "max_consumptions": 2,
   "max_consumptions_per_user": 1,
   "consumption_lifetime": 60000,
-  "expiration_date": "2500-01-01T10:00:00.000000Z",
+  "expiration_date": "2500-01-01T10:00:00.000000",
   "metadata": {
     "a_key": "a_value"
   },


### PR DESCRIPTION
Closes #12 

This PR updates tests that were failing after some minor changes in the API

- The error message when sending an invalid param to `admin.reset_password` was changed from `Invalid parameter provided` to `email and redirect_url are required`
- `admin.reset_password` doesn't raise an error anymore when sending an inexistent email but succeed instead without sending an email.
- Date format was changed