### PR TITLE
Revert date format change

### DIFF
--- a/tests/01__admin/01__admin_session_tests.robot
+++ b/tests/01__admin/01__admin_session_tests.robot
@@ -79,7 +79,7 @@ Request to reset password successfully with correct credentials
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${ADMIN_EMAIL}    redirect_url=${RESET_PASSWORD_URL}
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response
@@ -90,7 +90,7 @@ Request to reset password successfully even when an invalid email is provided
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=invalid@email.com    redirect_url=${RESET_PASSWORD_URL}
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response
@@ -101,7 +101,7 @@ Request to reset password fails if required parameters are not provided
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${None}    redirect_url=${RESET_PASSWORD_URL}
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response
@@ -114,7 +114,7 @@ Request to reset password fails if an invalid redirect URL is provided
     ${data}    Get Binary File    ${JSON_PATH}/reset_password.json
     &{override}    Create Dictionary    email=${ADMIN_EMAIL}    redirect_url=http://invalid.com
     ${data}    Update Json    ${data}    &{override}
-    &{headers}    Build Authenticated Admin Request Header
+    &{headers}    Build Admin Request Header
     # Perform request
     ${resp}    Post Request    api    ${ADMIN_RESET_PASSWORD}    data=${data}    headers=${headers}
     # Assert response

--- a/tests/01__admin/resources/transaction_request/create_transaction_request_all_params.json
+++ b/tests/01__admin/resources/transaction_request/create_transaction_request_all_params.json
@@ -10,7 +10,7 @@
     "max_consumptions": 2,
     "max_consumptions_per_user": 1,
     "consumption_lifetime": 60000,
-    "expiration_date": "2500-01-01T10:00:00.000000",
+    "expiration_date": "2500-01-01T10:00:00.000000Z",
     "metadata": {
         "a_key": "a_value"
     },


### PR DESCRIPTION
Closes #12 

This PR updates the date format of a test that reverted in the API.
Also removes the authentication header from request when not needed.